### PR TITLE
Individual guards and named views

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### v2.2.0
+* `easyroute-core` updated to 1.1.0;
+* named outlets - use two `RouterOutlet` on a single
+page, declare components for them by name;
+* individual beforeEnter hooks for routes;
+* `useCurrentRoute` hook for easy access to current
+route object in every route.
+
 ### v2.1.6
 * `easyroute-core` updated to 1.0.2;
 * fixed premature afterHook trigger with lazy loaded components.

--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -105,6 +105,7 @@ module.exports = (env, argv) => {
             '/page/css-transitions',
             '/page/navigation-guards',
             '/page/silent-mode',
+            '/page/named-outlets',
             '/playground/demo/params'
           ]
         })

--- a/demo-app/src/Components/MainMenu.svelte
+++ b/demo-app/src/Components/MainMenu.svelte
@@ -1,63 +1,84 @@
 <script>
-    import { RouterLink } from '../../../lib'
+    import { RouterLink, useCurrentRoute } from '../../../lib'
+    import { onDestroy } from 'svelte'
+    let routePath = ''
+
+    const unsubscribe = useCurrentRoute((route) => {
+        routePath = route.fullPath
+    })
+
+    const menu = [
+        {
+            url: '/page/installation',
+            title: 'Installation'
+        },
+        {
+            url: '/page/getting-started',
+            title: 'Getting started'
+        },
+        {
+            title: 'divider'
+        },
+        {
+            url: '/page/dynamic-matching',
+            title: 'Dynamic route matching'
+        },
+        {
+            url: '/page/current-route-info',
+            title: 'Current route info'
+        },
+        {
+            url: '/page/router-links',
+            title: 'Router links'
+        },
+        {
+            url: '/page/programmatic-navigation',
+            title: 'Programmatic navigation'
+        },
+        {
+            url: '/page/nested-routes',
+            title: 'Nested routes'
+        },
+        {
+            url: '/page/navigation-guards',
+            title: 'Navigation guards'
+        },
+        {
+            url: '/page/css-transitions',
+            title: 'CSS transitions'
+        },
+        {
+            url: '/page/named-outlets',
+            title: 'Named outlets (views)'
+        },
+        {
+            url: '/page/silent-mode',
+            title: 'Silent mode'
+        },
+        {
+            title: 'divider'
+        },
+        {
+            url: '/playground/demo/params?text=query',
+            title: 'Playground'
+        }
+    ]
+
+    onDestroy(unsubscribe)
 </script>
 
 <ul class="uk-nav uk-nav-default">
-    <li class="uk-active">
-        <RouterLink to="/page/installation">
-            Installation
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/getting-started">
-            Getting started
-        </RouterLink>
-    </li>
-    <li class="uk-nav-divider"></li>
-    <li>
-        <RouterLink to="/page/dynamic-matching">
-            Dynamic route matching
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/current-route-info">
-            Current route info
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/router-links">
-            Router links
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/programmatic-navigation">
-            Programmatic navigation
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/nested-routes">
-            Nested routes
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/navigation-guards">
-            Navigation guards
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/css-transitions">
-            CSS transitions
-        </RouterLink>
-    </li>
-    <li>
-        <RouterLink to="/page/silent-mode">
-            Silent mode
-        </RouterLink>
-    </li>
-    <li class="uk-nav-divider"></li>
-    <li>
-        <RouterLink to="/playground/demo/params?text=query">
-            Playground
-        </RouterLink>
-    </li>
+
+    {#each menu as item}
+        {#if item.title === 'divider'}
+            <li class="uk-nav-divider"></li>
+        {:else}
+            <li class:uk-active={ routePath === item.url }>
+                <RouterLink to="{ item.url }">
+                    { item.title }
+                </RouterLink>
+            </li>
+        {/if}
+    {/each}
+
 </ul>

--- a/demo-app/src/Pages/Index.svelte
+++ b/demo-app/src/Pages/Index.svelte
@@ -27,6 +27,12 @@
         <li>
             Named routes
         </li>
+        <li>
+            Named outlets (views)
+        </li>
+        <li>
+            Global and individual navigation hooks
+        </li>
         <li>Hash, history and silent modes</li>
     </ul>
 

--- a/demo-app/src/Router/index.js
+++ b/demo-app/src/Router/index.js
@@ -25,6 +25,23 @@ const routes = [
         meta: {
           test: 'test'
         },
+        beforeEnter: async (to, from, next) => {
+          console.log(`[beforeEnter hook]: fetching page data`)
+          const { slug } = to.params
+          try {
+            to.meta.pageText = await fetchSlugMarkdown(slug)
+            const titlePart = to.meta.pageText
+              .split('\n')[0]
+              .replace(/^(#+ )/, '')
+            document.title = titlePart
+              ? `${titlePart} | Svelte Easyroute`
+              : 'Svelte Easyroute'
+            next()
+          } catch (e) {
+            console.error(e)
+            next('/not-found')
+          }
+        },
         component: () =>
           import(/*webpackChunkName: "mdpage" */ '../Pages/Markdown.svelte')
       },
@@ -63,26 +80,11 @@ const router = new Router({
 
 router.beforeEach = async (to, from, next) => {
   nprogress.start()
-  if (to.name === 'Page') {
-    console.log(`[BeforeEachHook]: fetching page data`)
-    const { slug } = to.params
-    try {
-      to.meta.pageText = await fetchSlugMarkdown(slug)
-      const titlePart = to.meta.pageText.split('\n')[0].replace(/^(#+ )/, '')
-      document.title = titlePart
-        ? `${titlePart} | Svelte Easyroute`
-        : 'Svelte Easyroute'
-      next()
-    } catch (e) {
-      console.error(e)
-      next('/not-found')
-    }
-  } else {
-    document.title = to.meta.title
-      ? `${to.meta.title} | Svelte Easyroute`
-      : 'Svelte Easyroute'
-    next()
-  }
+  if (to.name === 'Page') next()
+  document.title = to.meta.title
+    ? `${to.meta.title} | Svelte Easyroute`
+    : 'Svelte Easyroute'
+  next()
 }
 
 router.afterEach = () => {

--- a/demo-app/src/texts/current-route-info.md
+++ b/demo-app/src/texts/current-route-info.md
@@ -1,12 +1,17 @@
 ## Current route info
 From every child component you can access current 
-route state. Just put in the <script> tag:
+route state. There are two ways to do this:
+
+### 1. Export variable in outlet's child component
+
+If your component is direct child of `<RouterOutlet>`,
+ust put in the <script> tag:
 ```javascript
 export let currentRoute
 ```
 That's it! 
 
-### Example
+#### Example:
 ```javascript
 {
   "fullPath": "/test/value?name=Alex&age=23",
@@ -22,6 +27,32 @@ That's it!
   }
 }
 ```
+
+### 2. useCurrentRoute hook
+In any component wrapped with `<EasyrouteProvider>`, 
+on any level of nesting, you can use `useCurrentRoute`
+hook. It is a custom implementation of Observable
+pattern, so you can "subscribe" to current route
+object. It goes like this:
+
+```html
+<script>
+    // Component.svelte
+
+    import { useCurrentRoute } from "svelte-easyroute"
+    import { onDestroy } from "svelte"
+    
+    const unsubscribe = useCurrentRoute((currentRoute) => {
+        console.log(currentRoute)
+    })
+    
+    onDestroy(unsubscribe)
+</script>
+```
+**Don't forget** to `unsibscribe` when leaving your component!
+If you will not, it can cause memory leak.
+
+### Bonus
 
 You can also get current outlet HTML element like this:
 ```javascript

--- a/demo-app/src/texts/named-outlets.md
+++ b/demo-app/src/texts/named-outlets.md
@@ -1,0 +1,39 @@
+## Named outlets
+
+If you need to display multiple route-depending
+views on a single page, for example, creating 
+a layout with sidebar views and main views - 
+this is where you may need named outlets (or
+named views, like in Vue.js). 
+Instead of having one single outlet 
+in your view, you can have multiple and give 
+each of them a name. A `RouterOutlet` without a 
+name will be given default as its name.
+
+```html
+<RouterOutlet /> <!-- "default" outlet -->
+<RouterOutlet name="sidebar-left" /> <!-- "sidebar-left" outlet -->
+<RouterOutlet name="sidebar-right" /> <!-- "sidebar-right" outlet -->
+```
+An outlet is rendered by using a component, 
+therefore multiple outlets require multiple 
+components for the same route. Make sure to 
+use the components (with an s) option:
+
+```javascript
+const router = new Router({
+  routes: [
+    {
+      path: '/',
+      components: {
+        default: Foo,
+        'sidebar-left': Bar,
+        'sidebar-right': Baz
+      }
+    }
+  ]
+})
+```
+
+You can use named outlets on each level, even in 
+nested routes: just put a name attribute to `<RouterOutlet>`

--- a/demo-app/src/texts/navigation-guards.md
+++ b/demo-app/src/texts/navigation-guards.md
@@ -1,9 +1,11 @@
 ## Navigation guards
 
-f you want to do something before component is 
+If you want to do something before component is 
 changed by router, you can add navigation guards.
 
-For now there are two navigation 
+### Global guards and hooks
+
+There are two global navigation 
 hooks: beforeEach and afterEach.
 
 You can specify them like that: 
@@ -25,6 +27,26 @@ continues transition. If you will not put "next()"
 in beforeEach methond - transition will NEVER 
 complete.
 
+### Individual route guard
+You can set an individual guard for each route:
+```javascript
+const router = new Router({
+    // ...
+    routes: [
+        {
+            path: '/path',
+            component: Component,
+            beforeEnter: (to, from, next) {
+                console.log('I am here!')
+                next()
+            }   
+        }
+    ]
+})
+```
+These guards have the exact same signature as global before guards.
+
+**Note**: all router guards functions can be `async`.
 ### More control
 
 `next` can be used without arguments, then route 

--- a/lib/EasyrouteProvider.svelte
+++ b/lib/EasyrouteProvider.svelte
@@ -1,5 +1,6 @@
 <script>
-    import Router from 'easyroute-core'
+    // import Router from 'easyroute-core'
+    import Router from '../../easyroute/lib/dist/index'
     import { setContext } from 'svelte'
     export let router = null
 

--- a/lib/EasyrouteProvider.svelte
+++ b/lib/EasyrouteProvider.svelte
@@ -1,6 +1,5 @@
 <script>
-    // import Router from 'easyroute-core'
-    import Router from '../../easyroute/lib/dist/index'
+    import Router from 'easyroute-core'
     import { setContext } from 'svelte'
     export let router = null
 

--- a/lib/RouterOutlet.svelte
+++ b/lib/RouterOutlet.svelte
@@ -5,6 +5,7 @@
     export let router = null
     export let transition = null
     export let forceRemount = false
+    export let name = 'default'
 
     if (router) {
         console.warn('[Easyroute] Passing router as a prop in outlet is deprecated in v2.1.5.' +
@@ -58,7 +59,9 @@
     async function pickRoute(routes) {
         const currentRoute = routes.find(route => route.nestingDepth === currentDepth)
         if (currentRoute) {
-            const component = currentRoute.component
+            let component
+            if (name === 'default') component = currentRoute.component || currentRoute.components.default
+            else component = currentRoute.components ? currentRoute.components[name] : null
             changeComponent(component, currentRoute.id)
             await delay(transitionData ? transitionData.leavingDuration : 0)
             routeData = _router.currentRoute

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,4 @@
-// import Router from 'easyroute-core'
-import Router from '../../easyroute/lib/dist/index'
+import Router from 'easyroute-core'
 import { getContext } from 'svelte'
 
 const useCurrentRoute = (listener) => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,15 @@
-import Router from 'easyroute-core'
+// import Router from 'easyroute-core'
+import Router from '../../easyroute/lib/dist/index'
+import { getContext } from 'svelte'
+
+const useCurrentRoute = (listener) => {
+  const context = getContext('easyrouteContext')
+  if (!context) throw new Error('[Easyroute] No router context found')
+  return context.router.currentRouteData.subscribe(listener)
+}
 
 export default Router
 export { default as RouterOutlet } from './RouterOutlet.svelte'
 export { default as RouterLink } from './RouterLink.svelte'
 export { default as EasyrouteProvider } from './EasyrouteProvider.svelte'
+export { useCurrentRoute }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "svelte-easyroute",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -5237,9 +5237,9 @@
       }
     },
     "easyroute-core": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/easyroute-core/-/easyroute-core-1.0.2.tgz",
-      "integrity": "sha512-xwb1JhLNs3+MyICPsfb+aeyD73G8HfyxMugGxFjdwTjzQqaCco7nGAkA0qrKr36NZuDeKIUuEg4ypV9BXaLrFA=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/easyroute-core/-/easyroute-core-1.1.0.tgz",
+      "integrity": "sha512-OfVQKNTomZuJ4FIEd8cLxUaEqGk21RDSOoDt6L5ObeRNbwhQ1mCDitJ1E8nqW0PonIpzR2oVwQfiFYTQd6POiw=="
     },
     "ecc-jsbn": {
       "version": "0.1.2",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "svelte-easyroute",
   "description": "Config-based router for Svelte in style of Vue Router",
-  "version": "2.1.6",
+  "version": "2.2.0",
   "main": "lib/index.js",
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "test": "jest"
   },
   "dependencies": {
-    "easyroute-core": "1.0.2"
+    "easyroute-core": "1.1.0"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
* `easyroute-core` updated to 1.1.0;
* named outlets - use two `RouterOutlet` on a single
page, declare components for them by name;
* individual beforeEnter hooks for routes;
* `useCurrentRoute` hook for easy access to current
route object in every route.